### PR TITLE
Feature: Added LED Library in Kernel-Space

### DIFF
--- a/kernel/include/led/led.h
+++ b/kernel/include/led/led.h
@@ -1,0 +1,25 @@
+#ifndef __KERN_LED_H
+#define __KERN_LED_H
+
+#include "gpio/bcm2711/gpio.h"
+
+/**
+ * @brief Convenience function that initializes a pin to be used
+ * as an LED.
+ * 
+ * @param pin pin to use as LED. 
+ */
+void led_init(int pin, int state);
+
+/**
+ * @brief Toggles LED depending on the state of the pin.
+ * 
+ * @param pin pin to use as LED.
+ */
+void led_toggle(int pin);
+
+/* these functions wrap the gpio driver for clarity */
+void led_set(int pin);
+void led_clear(int pin);
+
+#endif

--- a/kernel/src/kernel.c
+++ b/kernel/src/kernel.c
@@ -1,20 +1,24 @@
 #include "gpio/bcm2711/gpio.h"
 #include "gpc/bcm2711/gpc.h"
 #include "common.h"
+#include "led/led.h"
 
 void kernel_main() {
     /* initialize the gpio map */
     init_gpio_map();
     init_gpc();
-    
-    puts("Hello, welcome to the GPIO-Communication Protocol!\n");
-    puts("o7\n");
+
+    led_init(21, 1);
+    led_init(20, 0);
+    led_init(16, 1);
 
     while (1) {
-        exec();
-    }
-    
+        led_toggle(21);
+        led_toggle(20);
+        led_toggle(16);
 
-    delay(4);
+        delay(1);
+    }
+
     panic();
 }

--- a/kernel/src/led.c
+++ b/kernel/src/led.c
@@ -1,0 +1,23 @@
+#include "led/led.h"
+
+void led_init(int pin, int state) {
+    gpio_func(pin, GPIO_FUNC_OUT);
+    gpio_clear(pin);
+
+    if (state) 
+        led_set(pin);
+}
+
+void led_set(int pin) {
+    gpio_set(pin);
+}
+
+void led_clear(int pin) {
+    gpio_clear(pin);
+}
+
+void led_toggle(int pin) {
+    if (gpio_lev(pin))
+        led_clear(pin);
+    else led_set(pin);
+}


### PR DESCRIPTION
Added a library that uses the GPIO Driver to provide an abstraction for LEDs.

With this library:
- [x] `led_init` sets function on a given pin AND sets an initial state.
- [x] led_set, led_clear provide wrapper functions that do gpio_set, gpio_clear. This is significant because from a SWE POV, this helps communicate intent.

```
I am not a fan of this being in the kernel/include path and will most likely be pushed to a lib folder later.
```