### PR TITLE
Feature: Bare-Bones Sprintf

### DIFF
--- a/kernel/include/math/defs.h
+++ b/kernel/include/math/defs.h
@@ -1,0 +1,6 @@
+#ifndef __KERN_MATH_DEFS_H
+#define __KERN_MATH_DEFS_H
+
+unsigned int pow(int base, int exp);
+
+#endif

--- a/kernel/include/strings/strings.h
+++ b/kernel/include/strings/strings.h
@@ -1,0 +1,17 @@
+#ifndef __KERN_STRING_H
+#define __KERN_STRING_H
+
+#define SPRINTF_BUFFER_MAX 512
+
+/**
+ * @brief Converts an array of arguments and a format stringh
+ * to a string.
+ * 
+ * @param dest Destination buffer to write the string to.
+ * @param fmt Format string.
+ * @param args Argument List.
+ * @return int number of bits written
+ */
+int sprintf(char *dest, char *fmt, void *args);
+
+#endif

--- a/kernel/src/kernel.c
+++ b/kernel/src/kernel.c
@@ -2,22 +2,22 @@
 #include "gpc/bcm2711/gpc.h"
 #include "common.h"
 #include "led/led.h"
+#include "strings/strings.h"
 
 void kernel_main() {
     /* initialize the gpio map */
     init_gpio_map();
     init_gpc();
 
-    led_init(21, 1);
-    led_init(20, 0);
-    led_init(16, 1);
+    char destination[32];
+    unsigned int args[1];
+    args[0] = 123456789;
+
+    sprintf(&destination[0], "\nCount: %d\n", (void *)(args));
+    puts(destination);
 
     while (1) {
-        led_toggle(21);
-        led_toggle(20);
-        led_toggle(16);
-
-        delay(1);
+        exec();
     }
 
     panic();

--- a/kernel/src/math.c
+++ b/kernel/src/math.c
@@ -1,0 +1,15 @@
+#include "math/defs.h"
+
+unsigned int pow(int base, int exp) {
+    int result = 1;
+    if (exp == 0)
+        return result;
+
+    result *= 10;
+
+    for (int i = 0; i < (exp - 1); i++) {
+        result *= base;
+    }
+
+    return result;
+}

--- a/kernel/src/strings.c
+++ b/kernel/src/strings.c
@@ -1,0 +1,76 @@
+#include "strings/strings.h"
+#include "math/defs.h"
+
+enum SPRINTF_STATE {
+    COPY,
+    REPLACE,
+    IDENTIFYING,
+};
+
+static int find_depth(int n) {
+    if ((n / 10) == 0) {
+        return 0;
+    }
+
+    return find_depth(n/10) + 1;
+}
+
+/**
+ * @brief Handles an integer argument for sprintf and appends to the dest.
+ * 
+ * @param dest destination buffer where string is expected.
+ * @param di destination index.
+ * @param num number as argument to %d.
+ */
+static void sprintf_handle_uint(char *dest, unsigned int *di, void *args) {
+    unsigned int num = ((unsigned int *)(args))[0];
+    unsigned int depth = find_depth(num);
+    unsigned int power = pow(10, depth);
+
+    while (power > 0) {
+        // we do mod 57 to restrain the output encoding to only ascii 
+        // numbers (aruably not needed since we divide by power, but...)
+        *(dest + *di) = (char) (((num / power) + 48)); 
+        num = num - ((num / power) * power);
+        power /= 10;
+        *di = *di + 1;
+    }
+}
+
+static void sprintf_handle_hex(char *dest, unsigned int *di, void *args) {
+    // to be implemented
+}
+
+static void sprintf_append(char *dst, unsigned int *di, char c) {
+    dst[*di] = c;
+    *di = *di + 1;
+}
+
+int sprintf(char *dest, char *fmt, void *args) {
+    unsigned int di = 0;
+    unsigned int va_index = 0;
+    
+    for (char *c = fmt; *c != '\0'; c++) {
+        if (*c == '%') {
+            switch (*(c + 1)) {
+            case 'd':
+                sprintf_handle_uint(dest, &di, (args + va_index));
+                va_index += sizeof(unsigned int);
+                c++;
+                break;
+
+            default:
+                sprintf_append(dest, &di, *c);
+                break;
+            }
+
+        } else {
+            sprintf_append(dest, &di, *c);
+        }
+    }
+
+    if (*(dest + di) != '\0') {
+        dest[di] = '\0';
+    }
+    return 0;
+}


### PR DESCRIPTION
We've just added support for a bare-bones sprintf implementation. We needed a way to write to our terminal and format some numbers for fact-checking purposes - and so sprintf was born. 

In it's current state:
- [x] It is required that you allocate an array outside of a call to `sprintf`.
- [x] Sprintf will append a null byte in the case that the fmt string is less than the size allocated to the destination buffer (this won't be needed in future implementations once we get malloc in-place, or if we switch to a preemptive length calculation model). 